### PR TITLE
Support for multi-value parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 poetry.lock
 starlette_lambda.egg-info
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 poetry.lock
 starlette_lambda.egg-info
 /.idea/
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-starlette==0.11.4
-uvicorn==0.3.32
+.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ install_requires = [
 
 setup(
     name="starlette-lambda",
-    version="0.1.0",
+    version="0.1.1",
     author="Alokin",
     author_email="hello@alokin.in",
     description="",

--- a/starlette_lambda/aws.py
+++ b/starlette_lambda/aws.py
@@ -17,20 +17,10 @@ class LambdaFunction:
         loop.create_task(lifespan.run())
         loop.run_until_complete(lifespan.wait_startup())
 
-        connection_scope = {
-            'type': 'http',
-            'http_version': '1.1',
-            'scheme': 'http',
-            'method': event['httpMethod'],
-            'root_path': '',
-            'path': event['path'],
-            'query_string': urllib.parse.urlencode(event['queryStringParameters']),
-            'headers': event['headers'].items(),
-            'x-aws-lambda': {
-                'requestContext': event['requestContext'],
-                'lambdaContext': context
-            }
-        }
+        connection_scope = self.get_connection_scope(
+            event=event,
+            context=context
+        )
 
         async def _receive() -> Message:
             body = event['body']
@@ -57,3 +47,20 @@ class LambdaFunction:
         loop.run_until_complete(lifespan.wait_shutdown())
 
         return response
+
+    def get_connection_scope(self, event, context):
+        return {
+            'type': 'http',
+            'http_version': '1.1',
+            'scheme': 'http',
+            'method': event['httpMethod'],
+            'root_path': '',
+            'path': event['path'],
+            'query_string': urllib.parse.urlencode(
+                event['queryStringParameters']),
+            'headers': event['headers'].items(),
+            'x-aws-lambda': {
+                'requestContext': event['requestContext'],
+                'lambdaContext': context
+            }
+        }

--- a/tests/test_multi_value.py
+++ b/tests/test_multi_value.py
@@ -1,0 +1,20 @@
+from starlette.applications import Starlette
+
+from starlette_lambda.aws import LambdaFunction
+
+
+def test_multi_value():
+    scope = LambdaFunction(asgi=Starlette()).get_connection_scope(event={
+        'httpMethod': 'GET',
+        'path': '/foo',
+        'headers': {},
+        'requestContext': {},
+        'queryStringParameters': {'make': 'TOYOTA', 'zip_code': '65301'},
+        'multiValueQueryStringParameters': {
+            'make': ['TOYOTA'],
+            'zip_code': ['02368', '65301']
+        }
+    }, context={})
+
+    assert scope['query_string'] == 'make=TOYOTA&zip_code=02368&zip_code=65301'
+

--- a/tests/test_multi_value.py
+++ b/tests/test_multi_value.py
@@ -4,17 +4,22 @@ from starlette_lambda.aws import LambdaFunction
 
 
 def test_multi_value():
-    scope = LambdaFunction(asgi=Starlette()).get_connection_scope(event={
-        'httpMethod': 'GET',
-        'path': '/foo',
-        'headers': {},
-        'requestContext': {},
+    query_string = LambdaFunction(asgi=Starlette()).get_query_string(event={
         'queryStringParameters': {'make': 'TOYOTA', 'zip_code': '65301'},
         'multiValueQueryStringParameters': {
-            'make': ['TOYOTA'],
             'zip_code': ['02368', '65301']
         }
-    }, context={})
+    })
 
-    assert scope['query_string'] == 'make=TOYOTA&zip_code=02368&zip_code=65301'
+    assert query_string == 'make=TOYOTA&zip_code=02368&zip_code=65301'
 
+
+def test_pseudo_multi_value():
+    query_string = LambdaFunction(asgi=Starlette()).get_query_string(event={
+        'queryStringParameters': {'make': 'TOYOTA', 'zip_code': '65301'},
+        'multiValueQueryStringParameters': {
+            'zip_code': ['02368']
+        }
+    })
+
+    assert query_string == 'make=TOYOTA&zip_code=02368'

--- a/tests/test_starlette_lambda.py
+++ b/tests/test_starlette_lambda.py
@@ -34,7 +34,6 @@ class LambdaContext(object):
             self.client_context.client = None
         self.identity = None
 
-
     def get_remaining_time_in_millis(self):
         return None
 


### PR DESCRIPTION
Under multi-value GET parameters, we mean, for example, this:

```
GET /foo/?names=John&names=Mary
```

In Python code, we would like to get something like

```
>>> names
['John', 'Mary']
```

AWS runtime provides such parameters in a special field of `event` argument to Lambda handler function, called `multiValueQueryStringParameters`.

This PR adds support for that field and data hidden in it.